### PR TITLE
Removes Journal title h1

### DIFF
--- a/assets/css/clean.css
+++ b/assets/css/clean.css
@@ -332,3 +332,10 @@ footer svg {
 .article-img {
     filter: brightness(50%);
 }
+
+.journal-name {
+    font-size: 2.5rem;
+    margin-bottom: .5rem;
+    font-weight: 500;
+    line-height: 1.2;
+}

--- a/templates/core/base.html
+++ b/templates/core/base.html
@@ -42,7 +42,7 @@
                 </div>
                 {% endif %}
                 <div class="col-md-10">
-                    <h1 class="journal-name">{{ request.journal.name }}</h1>
+                    <p class="journal-name">{{ request.journal.name }}</p>
                 </div>
             </div>
 

--- a/templates/journal/homepage_elements/about.html
+++ b/templates/journal/homepage_elements/about.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <div class="row" id="about_journal">
     <div class="col-md-12">
-        <h2 class="index-header">{{ title_value }}</h2>
+        <h1 class="index-header">{{ title_value }}</h1>
         <p>{{ journal_settings.general.journal_description|safe }}</p>
     </div>
 </div>

--- a/templates/journal/homepage_elements/carousel.html
+++ b/templates/journal/homepage_elements/carousel.html
@@ -2,7 +2,7 @@
 
 <div class="row">
     <div class="col-md-12">
-        <h2 class="sr-only">Latest Articles & News</h2>
+        <h1 class="sr-only">Latest Articles & News</h1>
         <div id="carousel" class="carousel slide" data-ride="carousel">
             <div class="carousel-inner" aria-roledescription="carousel" aria-label="News and article carousel">
                 {% for carousel_item in carousel_items %}

--- a/templates/journal/homepage_elements/featured.html
+++ b/templates/journal/homepage_elements/featured.html
@@ -3,7 +3,7 @@
 
 <div class="row">
     <div class="col-md-12">
-        <h2 class="index-header">{% trans 'Featured Articles' %}</h2>
+        <h1 class="index-header">{% trans 'Featured Articles' %}</h1>
     </div>
     {% for fa in featured_articles %}
         <div class="col-md-4 row-eq-height">

--- a/templates/journal/homepage_elements/journals.html
+++ b/templates/journal/homepage_elements/journals.html
@@ -1,7 +1,7 @@
 <div class="row">
     <div class="col-md-12">
         <br/>
-        <h2 class="index-header">Featured Journals</h2>
+        <h1 class="index-header">Featured Journals</h1>
     </div>
     {% for current_journal in featured_journals %}
         <div class="col-md-2 row-eq-height">

--- a/templates/journal/homepage_elements/news.html
+++ b/templates/journal/homepage_elements/news.html
@@ -5,7 +5,7 @@
 <section>
     <div class="row">
         <div class="col-md-12">
-            <h2 class="index-header">{% trans "Latest News" %}</h2>
+            <h1 class="index-header">{% trans "Latest News" %}</h1>
         </div>
         {% for item in news_items %}
             <div class="col-md-6 row-eq-height">

--- a/templates/journal/homepage_elements/popular.html
+++ b/templates/journal/homepage_elements/popular.html
@@ -4,9 +4,9 @@
 <div class="row">
     <div class="col-md-12">
         {% if most_downloaded %}
-            <h2 class="index-header">{% trans 'Most Popular Articles' %}</h2>
+            <h1 class="index-header">{% trans 'Most Popular Articles' %}</h1>
         {% else %}
-            <h2 class="index-header">{% trans 'Featured Articles' %}</h2>
+            <h1 class="index-header">{% trans 'Featured Articles' %}</h1>
         {% endif %}
     </div>
     {% for article in popular_articles %}

--- a/templates/journal/homepage_elements/preprints.html
+++ b/templates/journal/homepage_elements/preprints.html
@@ -3,7 +3,7 @@
 
 <div class="row">
     <div class="col-md-12">
-        <h2 class="index-header">{% trans 'Featured Preprints' %}</h2>
+        <h1 class="index-header">{% trans 'Featured Preprints' %}</h1>
     </div>
     {% include "elements/preprint_block.html" with preprints=preprints %}
 </div>


### PR DESCRIPTION
- Journal-name is now wrapped in a paragraph with h1 styling
- Homepage elements are now `<h1>` to preserve correct navigation structure on the page